### PR TITLE
[codex] Document LongDS executor build requirements

### DIFF
--- a/longds/README.md
+++ b/longds/README.md
@@ -71,6 +71,8 @@ LongDS uses DSGym's container manager to allocate isolated Python execution envi
 
 Build and start the LongDS executor pool:
 
+> Note: The complete executor image is approximately 12 GB. Ensure sufficient disk space and a stable network connection before building.
+
 ```bash
 cd /path/to/DataMind/longds/DSGym/executors
 
@@ -84,6 +86,8 @@ python generate_compose.py \
 
 docker compose -f docker-compose.yml up -d --build
 ```
+
+> If manager-to-executor requests return `502 Bad Gateway` while using a proxy or VPN, add the Docker service names to `NO_PROXY`.
 
 Stop the executor pool:
 


### PR DESCRIPTION
## Summary
- note that the complete LongDS executor image is approximately 12 GB
- document the NO_PROXY check for manager-to-executor 502 errors when using a proxy or VPN

## Validation
- compared longds/README.md against the latest origin/main
- confirmed the PR contains only these two documentation notes